### PR TITLE
Fix bugs

### DIFF
--- a/ipArt.c
+++ b/ipArt.c
@@ -477,7 +477,7 @@ rtArtFreeRoute (rtTable* pt, routeEnt* r)
  *         pEnt      There is an existing route that has the same
  *                   IP prefix (address and prefix length).
  *                   `pEnt' must be freed in this case.
- *                   
+ *
  */
 static routeEnt*
 rtArtInsertRoute (rtTable* pt, routeEnt* pEnt)
@@ -584,7 +584,6 @@ rtArtDeleteRoute (rtTable* pt, u8* pDest, int plen)
     if ( plen == 0 ) {
         pEnt = pt->root[1].ent;
         pt->root[1].ent = NULL;
-        pt->nRoutes--;
         goto FreeAndReturn;
     }
 
@@ -627,6 +626,7 @@ rtArtDeleteRoute (rtTable* pt, u8* pDest, int plen)
 
 FreeAndReturn:
     if ( pEnt == NULL ) return false;
+    pt->nRoutes--;
     rtArtFreeRoute(pt, pEnt);
     return true;
 }

--- a/ipArt.h
+++ b/ipArt.h
@@ -147,7 +147,7 @@ void      rtArtCollectStats(rtTable* pt, subtable ps);
  * @name  bitCmp8
  *
  * @brief Compare between arbitrary bits of a byte
- *        
+ *
  *
  * @param[in] d1  Data 1 (one byte) to be compared.
  * @param[in] d2  Data 2 (one byte) to be compared.
@@ -177,7 +177,7 @@ bitCmp8 (u8 p1, u8 p2, int st, int end)
  * @name  bitStrCmp
  *
  * @brief Compare two bit strings
- *        
+ *
  *
  * @param[in] p1  Pointer to bit string 1 to be compared.
  * @param[in] p2  Pointer to bit string 2 to be compared.
@@ -298,7 +298,7 @@ cmpAddr (u8* p1, u8* p2, int plen)
             return false;
         }
     }
-    if ( len == plen ) {
+    if ( len == plen + 8 ) {
         return true;
     }
 

--- a/ipArtPathComp.c
+++ b/ipArtPathComp.c
@@ -264,8 +264,8 @@ checkSubtable (rtTable* pt, subtable t, bool* flag)
  * @brief Allocates a new subtable (trie node) of the given level.
  *
  * @param[in] p     Pointer to the routing table
- * @param[in] level 
- * @param[in] base  Subtable (trie node) default route. Assume a 
+ * @param[in] level
+ * @param[in] base  Subtable (trie node) default route. Assume a
  *                  newly allocated subtable (pst) is connected to
  *                  the index (i) of parent subtable (pn). `base'
  *                  must be pn[i].ent if pn[i] is a route entry.
@@ -277,7 +277,7 @@ rtArtPcNewSubTable (rtTable* p, int level, tableEntry base, u8* pa)
     register subtable t;
     register int a;
     size_t len;
-    
+
 
     assert(p && pa && level >= 0 && level < p->nLevels);
 
@@ -614,7 +614,7 @@ AddrComp:
  * @name  insertNewSubtable
  *
  * @brief Inserts a new subtable (trie node)
- *        
+ *
  *
  * @param[in] p     Pointer to the routing table
  * @param[in] pEnt  Pointer to the route entry to be inserted
@@ -728,7 +728,7 @@ insertNewSubtable (rtTable* p, routeEnt* pEnt,
  *         pEnt      There is an existing route that has the same
  *                   IP prefix (address and prefix length).
  *                   `pEnt' must be freed in this case.
- *                   
+ *
  */
 static routeEnt*
 rtArtPcInsertRoute (rtTable* pt, routeEnt* pEnt)
@@ -1012,6 +1012,7 @@ rtArtPcDeleteRoute (rtTable* pt, u8* pDest, int plen)
      * Handle default route
      */
     if (plen == 0) {
+        if ( pt->root[1].ent == NULL ) return false;
         rtArtFreeRoute(pt, pt->root[1].ent);
         pt->root[1].ent = NULL;
         --pt->nRoutes;
@@ -1075,7 +1076,6 @@ rtArtPcDestroy (rtTable** p)
     pt->flush(pt);
     free(pt->pPcSt);
     free(pt->root + pt->off);
-    free(pt->pTbl);
     free(pt->pEnt);
     free(pt->psi);
     free(pt);


### PR DESCRIPTION
Dear Yoichi,

Through testing and the use of sanitizers, I believed to have found several bugs that might be worth fixing.

ipArt.h (cmpAddr):
It should be noted that the ( len == plen ) check will never be true since the loop terminating condition is len <= plen.
In addition, with IPV6 and a plen of 128, we will have an OOB read of p1 and p2 when we check remaining bits.
I have changed the check to ( len == plen + 8 ) which correctly handles plen that are a multiple of 8.

ipArt.c (rtArtDeleteRoute): Subtract nRoutes only when default route is non-null
We are subtracting nRoutes even if the route is NULL, which can lead to nRoutes falling below 0.
In rtArtFlushRoutes, we would subsequently calloc(n, sizeof(routeEnt)) where n < 0, leading to an attempt to calloc a large amount of memory.

ipArtPathComp.c (rtArtPcDeleteRoute): Subtract nRoutes only when default route is non-null
Similar to above

ipArtPathComp.c (rtArtPcDestroy): Avoid freeing pt->pTbl which was not initialised
It seems that pt->pTbl was never initialised (unlike ipArt.c) and hence we are freeing a NULL pointer here

Best regards,
Damian